### PR TITLE
Added scale score calculation and display when loading a savefile

### DIFF
--- a/zelda-botw-master/index.html
+++ b/zelda-botw-master/index.html
@@ -38,9 +38,16 @@
 		</div>
 	</div>
 	<div id="toolbar" class="hidden padding-vertical">
+		<div id="extra-info" class="row wrapper padding-bottom">
+			<div class="six columns text-left">Scale Score: <span id='scale-score'></span>
+				<a target='_blank' href="https://www.reddit.com/r/Breath_of_the_Wild/comments/8fchiq/about_difficulty_scaling_for_enemies_and_weapons/">
+					?
+				</a>
+			</div>
+		</div>
 		<div class="row wrapper">
 			<div class="twelve columns text-center">
-				<span class="clickable" onclick="SavegameEditor.changeEndianess()" id="span-version"></span> | 
+				<span class="clickable" onclick="SavegameEditor.changeEndianess()" id="span-version"></span> |
 
 				<label for="select-filters">Filter: </label>
 				<select id="select-filters" onchange="SavegameEditor.showHashes(parseInt(this.value), 0)">
@@ -49,7 +56,7 @@
 				<label for="select-page">Page: </label>
 				<button id="page-prev" onclick="if(document.getElementById('select-page').selectedIndex>0)SavegameEditor.showHashes(parseInt(document.getElementById('select-filters').value), parseInt(document.getElementById('select-page').value)-1)">&laquo;</button>
 				<select id="select-page" onchange="SavegameEditor.showHashes(parseInt(document.getElementById('select-filters').value), parseInt(this.value))"></select>
-				<button id="page-next" onclick="if(document.getElementById('select-page').selectedIndex<document.getElementById('select-page').children.length-1)SavegameEditor.showHashes(parseInt(document.getElementById('select-filters').value), parseInt(document.getElementById('select-page').value)+1)">&raquo;</button> | 
+				<button id="page-next" onclick="if(document.getElementById('select-page').selectedIndex<document.getElementById('select-page').children.length-1)SavegameEditor.showHashes(parseInt(document.getElementById('select-filters').value), parseInt(document.getElementById('select-page').value)+1)">&raquo;</button> |
 
 				<button class="button with-icon icon3" onclick="closeFile()">Close file</button>
 				<button class="button colored blue with-icon icon9" onclick="saveChanges()">Save changes</button>

--- a/zelda-botw-master/zelda-botw-master.css
+++ b/zelda-botw-master/zelda-botw-master.css
@@ -62,6 +62,7 @@ tr:hover{background-color:#250e0e}
 .text-center{text-align:center}
 .text-justify{text-align:justify}
 .padding-vertical{padding:20px 0}
+.padding-bottom{padding:0px 0px 20px 0}
 .round{border-radius:3px}
 /* colors */
 .bg-light-gray{background-color:rgba(216,216,216,.99)}


### PR DESCRIPTION
User leoletino at reddit discovered [how the game scales in relation to enemies defeated](https://www.reddit.com/r/Breath_of_the_Wild/comments/8fchiq/about_difficulty_scaling_for_enemies_and_weapons/)

This score can be compared to the [tables he linked](https://docs.google.com/spreadsheets/d/e/2PACX-1vRSlyOD7FLAn1TUBn64Pu8Pld-WOfgcVByuywHMWvBTEV0j8potD1wkBs-MJJXf-gvEkpfItUCMqMk6/pubhtml#)

I have added the points each enemy adds when defeated as a dictionary and modified the preload function to calculate this score. The Score is displayed on the toolbar when a file is loaded. I've done this out of curiosity for myself to be able to check out my own score, thought this could be a nice addition to the Master Editor.