### PR TITLE
[Zelda BOTW only] Improved change of savedata format

### DIFF
--- a/zelda-botw/index.html
+++ b/zelda-botw/index.html
@@ -10,6 +10,7 @@
 	<link type="text/css" rel="stylesheet" href="./zelda-botw.css" media="all"/>
 	<script type="text/javascript" src="../savegame-editor.js"></script>
 	<script type="text/javascript" src="./zelda-botw.js"></script>
+	<script type="text/javascript" src="./zelda-botw.clipboard.js"></script>
 	<script type="text/javascript" src="./zelda-botw.data.js"></script>
 	<script type="text/javascript" src="./zelda-botw.locations.js"></script>
 	<script type="text/javascript" src="./zelda-botw.icons.js"></script>
@@ -66,7 +67,7 @@
 <div id="the-editor" class="wrapper hidden">
 	<!-- DEBUG -->
 	<div id="debug"></div>
-	
+
 	<!-- TAB: HOME -->
 	<div id="tab-home">
 		<!-- RUPEES -->
@@ -154,7 +155,7 @@
 				</select>
 			</div>
 		</div>
-		
+
 		<!-- Coordinates (Requires a memory editor) -->
 		<h3 class="border-green">Coordinates</h3>
 		<div class="row">
@@ -171,8 +172,8 @@
 		</div>
 
 
-	
-	
+
+
 
 
 		<!-- COMPLETIONISM -->
@@ -233,7 +234,7 @@
 			</div>
 		</div>
 	</div>
-	
+
 	<!-- TAB: WEAPONS -->
 	<div id="tab-weapons">
 		<h3>Weapons</h3><div id="container-weapons"></div>
@@ -343,7 +344,7 @@
 				<option value="AlbumPicture|PictureBook">Compendium</option>
 			</select>
 			<input id="input-custom-filter" type="text" placeholder="Search hash keys" onchange="BOTWMasterEditor.refreshResults()" />
-			
+
 			 | <label for="select-page">Page: </label>
 			<button id="page-prev" onclick="BOTWMasterEditor.prevPage()">&laquo;</button>
 			<select id="select-page" class="small" onchange="BOTWMasterEditor.setPage(this.selectedIndex)"></select>
@@ -352,7 +353,7 @@
 
 			<table id="table"></table>
 		</div>
-	</div>	
+	</div>
 </div>
 
 

--- a/zelda-botw/zelda-botw.clipboard.js
+++ b/zelda-botw/zelda-botw.clipboard.js
@@ -1,0 +1,100 @@
+/*
+    Clipboard used to store and loading item data when changing endianess.
+*/
+BOTW_Clipboard = {
+    clipboard: {
+		weapons: [],
+		bows: [],
+		shields: [],
+		clothes: [],
+		materials: [],
+		food: [],
+		other: []
+    },
+    clipboardFieldNames: {
+		ITEM_NAME: "name",
+		ITEM_ID: "id",
+		ITEM_MODIFIER: "modifier_id",
+		ITEM_MODIFIER_VALUE: "modifier_value",
+		ITEM_STOCK_OR_DURABILITY: "stock/durability"
+    },
+    _getClipboardAsArray: function(){
+		var result = [];
+		for(var category in this.clipboard){
+			for(var itemIndex=0;itemIndex<this.clipboard[category].length;itemIndex++){
+				var itemData = this.clipboard[category][itemIndex];
+				result.push(itemData);
+			}
+		}
+		return result;
+    },
+	_createClipboardItem: function(itemId, name, category, modifier, modifierValue, durabilityOrStock){
+		var item = {};
+		item[this.clipboardFieldNames.ITEM_ID] = itemId;
+		item[this.clipboardFieldNames.ITEM_NAME] = name;
+		//if(modifier !== null && modifierValue !== null){
+			item[this.clipboardFieldNames.ITEM_MODIFIER] = modifier;
+			item[this.clipboardFieldNames.ITEM_MODIFIER_VALUE] = modifierValue;
+		//}
+		item[this.clipboardFieldNames.ITEM_STOCK_OR_DURABILITY] = durabilityOrStock;
+		this.clipboard[category].push(item);
+	},
+	_pasteItemFromClipboard: function(itemData, itemNumber){
+		// If not item number is specified, the item will be added to the item pool
+		// By specifying an item number you can overwrite items
+		if(itemNumber === null){
+			itemNumber = document.getElementsByClassName("item-number").length;
+		}
+		if(itemNumber<SavegameEditor.Constants.MAX_ITEMS){
+			//var itemData = this.clipboard[clipboardCategory][itemClipboardIndex];
+			var itemId = itemData[this.clipboardFieldNames.ITEM_ID];
+			var category = SavegameEditor._getItemCategory(itemId);
+			var categorySingular = category.replace(/s$/,"");
+			var row = SavegameEditor._createItemRow(itemNumber, category);
+			document.getElementById('container-'+category).appendChild(row);
+			SavegameEditor._writeItemName(itemNumber,itemId);
+
+			SavegameEditor._setItemNameInDoc(itemNumber, itemData[this.clipboardFieldNames.ITEM_NAME]);
+			SavegameEditor._setItemDurabilityInDoc(itemNumber, itemData[this.clipboardFieldNames.ITEM_STOCK_OR_DURABILITY]);
+
+			//Add modifier select and input, since for some reason _createItemRow does not do that
+			var modifierColumns=['weapons','bows','shields'];
+			if(modifierColumns.indexOf(category)>=0){
+				if(category === "bows" && !itemId.startsWith('Weapon_')){
+					//do nothing (arrows do not have modifiers)
+				}else{
+					var modifierContainer=SavegameEditor._getRowFromItemNumber(itemNumber).children[2];
+					var modifierSelect = select('modifier-'+category+'-'+itemNumber, BOTW_Data.MODIFIERS.concat({value:0,name:SavegameEditor._toHexInt(0)}));
+					var modifierValue = inputNumber('modifier-'+category+'-value-'+itemNumber, 0, 0xffffffff, 0);
+					modifierContainer.appendChild(modifierSelect);
+					modifierContainer.appendChild(modifierValue);
+
+					SavegameEditor._setItemModifierInDoc(itemNumber, category, itemData[this.clipboardFieldNames.ITEM_MODIFIER]);
+					SavegameEditor._setItemModifierValueInDoc(itemNumber, category, itemData[this.clipboardFieldNames.ITEM_MODIFIER_VALUE]);
+				}
+			}
+		}
+	},
+    fillClipboardWithItems: function(){
+		var numberOfItems = document.getElementsByClassName("item-number").length;
+		for(var i=0; i<numberOfItems; i++){
+			var id = SavegameEditor._loadItemName(i);
+			var name = SavegameEditor._getItemNameFromDoc(i);
+			var category = SavegameEditor._getItemCategory(id);
+			var modifier = SavegameEditor._getItemModifierFromDoc(i,category);
+			var modifierValue = SavegameEditor._getItemModifierValueFromDoc(i,category);
+			var durabilityOrStock = SavegameEditor._getItemDurabilityFromDoc(i);
+			this._createClipboardItem(id, name, category, modifier, modifierValue, durabilityOrStock);
+		}
+	},
+    overwriteItemsWithClipboard: function(){
+
+		var clipboardAsArray = this._getClipboardAsArray();
+
+		for (var i=0; i<clipboardAsArray.length; i++){
+			var itemData = clipboardAsArray[i];
+			this._pasteItemFromClipboard(itemData, i);
+		}
+	}
+
+}


### PR DESCRIPTION
### Changes
Changes in this commit are:
* Implemented clipboard for temporarily saving and loading the items
data when changing endianess. This is because when endianess is changed,
item data is corrupted. This clipboard is a workaround for that issue.
* Added general purpose functions to zelda-botw.js for getting and
setting item data.
* Modifiers for weapons, bows and shields are now shown for new items
created via the Savegame Editor.
* Other minor refactors (in save(), load(),...)

### Testing

Tested locally (loading index.html) and once commit was pushed in https://pablopenna.github.io/savegame-editors/zelda-botw/

I successfully exported the savegame from my switch to Cemu.

Although I have only worked on items, some other player data is not corrupted and is exported just fine (e.g. Link's health, stamina or event flags).

### Known Issues (when changing endianess)
* Player position is corrupted, so you will appear somewhere else bugged. This is easily solved by teleporting.
* Horse data is corrupted, you still have your horses but their name, appearance and statistics get corrupted. A workaround is remodifying their data via this same SaveEditor.

NOTES: 

* I reused some pieces of code, hence duplicating some pieces of logic. I could have done a refactor but I tried to modify the original code the less possible.

* I recommend adding `?w=1` to the URL when checking the commit diff to ignore whitespace changes. My IDE removed trailing whitespaces from the files I touched.
