### PR TITLE
[TOTK] Fix duplicated options & max durability

### DIFF
--- a/savegame-editor.js
+++ b/savegame-editor.js
@@ -392,7 +392,16 @@ function select(id,options,func){
 				var option=document.createElement('option');
 				option.value=options[i].value;
 				option.innerHTML=options[i].name;
-				select.appendChild(option);
+				let dulicate = false;
+				for (const exist of select) {
+					if (exist.value === option.value && exist.innerHTML === option.innerHTML) {
+						dulicate = true;
+						break;
+					}
+				}
+				if (!dulicate) {
+					select.appendChild(option);
+				}
 			}else if(typeof options[i] === 'object'){
 				select.appendChild(options[i]);
 			}

--- a/zelda-totk/zelda-totk.js
+++ b/zelda-totk/zelda-totk.js
@@ -305,14 +305,6 @@ SavegameEditor={
 		return this._readString(offset, 64);
 	},*/
 
-	_getItemMaxDurability:function(item) {
-		let durability=TOTK_Data.DEFAULT_DURABILITY[item.id] || 70;
-		if (item.modifier == 0xd5cad39b || item.modifier == 0xb2c943ee) {
-			durability += item.modifierValue;
-		}
-		return durability;
-	},
-
 	_createItemRow:function(item){
 		var img=new Image();
 		img.id='icon-'+item.category+'-'+item.index;
@@ -345,7 +337,7 @@ SavegameEditor={
 
 		var lastColumn=document.createElement('div');
 		if(item.category==='weapons' || item.category==='bows' || item.category==='shields'){
-			var maxDurability=this._getItemMaxDurability(item);
+			var maxDurability=getItemMaxDurability(item);
 			var input1=inputNumber('item-durability-'+item.category+'-'+item.index, 1, maxDurability, item.durability);
 			input1.addEventListener('change', function(){
 				var newVal=parseInt(this.value);
@@ -383,6 +375,8 @@ SavegameEditor={
 			}
 			var selectModifier=select('item-modifier-'+item.category+'-'+item.index, modifiers, function(){
 				item.modifier=parseInt(this.value);
+				const durabilityInput = document.getElementById(`number-item-durability-${item.category}-${item.index}`);
+				durabilityInput.maxValue = getItemMaxDurability(item);
 			});
 			selectModifier.title='Modifier';
 			if(unknownModifier)
@@ -394,6 +388,8 @@ SavegameEditor={
 				var newVal=parseInt(this.value);
 				if(!isNaN(newVal) && newVal>0)
 					item.modifierValue=newVal;
+				const durabilityInput = document.getElementById(`number-item-durability-${item.category}-${item.index}`);
+				durabilityInput.maxValue = getItemMaxDurability(item);
 			});
 			inputModifierValue.title='Modifier value';
 
@@ -529,10 +525,10 @@ SavegameEditor={
 	
 	restoreDurability:function(catId){
 		this.currentItems[catId].forEach(function(item){
-			var durability=this._getItemMaxDurability(item);
+			var durability=getItemMaxDurability(item);
 			item.durability=durability;
 			document.getElementById('number-item-durability-'+item.category+'-'+item.index).value=durability;
-		}.bind(this));		
+		});		
 	},
 
 	setHorseName:function(i,val){
@@ -1297,4 +1293,12 @@ function loadMasterMode(){
 		};
 		document.getElementsByTagName('head')[0].appendChild(script);
 	}
+}
+
+function getItemMaxDurability(item) {
+	let durability=TOTK_Data.DEFAULT_DURABILITY[item.id] || 70;
+	if (item.modifier == 0xd5cad39b || item.modifier == 0xb2c943ee) {
+		durability += item.modifierValue;
+	}
+	return durability;
 }

--- a/zelda-totk/zelda-totk.js
+++ b/zelda-totk/zelda-totk.js
@@ -305,6 +305,14 @@ SavegameEditor={
 		return this._readString(offset, 64);
 	},*/
 
+	_getItemMaxDurability:function(item) {
+		let durability=TOTK_Data.DEFAULT_DURABILITY[item.id] || 70;
+		if (item.modifier == 0xd5cad39b || item.modifier == 0xb2c943ee) {
+			durability += item.modifierValue;
+		}
+		return durability;
+	},
+
 	_createItemRow:function(item){
 		var img=new Image();
 		img.id='icon-'+item.category+'-'+item.index;
@@ -337,10 +345,7 @@ SavegameEditor={
 
 		var lastColumn=document.createElement('div');
 		if(item.category==='weapons' || item.category==='bows' || item.category==='shields'){
-			var maxDurability=TOTK_Data.DEFAULT_DURABILITY[item.id] || 70;
-			/*if(item.modifier===0xd5cad39b || item.modifier===0xb2c943ee){ //Durability ↑/↑↑
-				maxDurability=0x7ffff000;
-			}*/
+			var maxDurability=this._getItemMaxDurability(item);
 			var input1=inputNumber('item-durability-'+item.category+'-'+item.index, 1, maxDurability, item.durability);
 			input1.addEventListener('change', function(){
 				var newVal=parseInt(this.value);
@@ -524,10 +529,10 @@ SavegameEditor={
 	
 	restoreDurability:function(catId){
 		this.currentItems[catId].forEach(function(item){
-			var durability=TOTK_Data.DEFAULT_DURABILITY[item.id] || 70;
+			var durability=this._getItemMaxDurability(item);
 			item.durability=durability;
 			document.getElementById('number-item-durability-'+item.category+'-'+item.index).value=durability;
-		});		
+		}.bind(this));		
 	},
 
 	setHorseName:function(i,val){


### PR DESCRIPTION
## Fix duplicated options in select

If the type of a weapon / bow / shield is changed in place, the modifier options are duplicated.

<img width="500" alt="image" src="https://github.com/marcrobledo/savegame-editors/assets/10684225/eb5fda16-8588-481f-8108-01d16e038f48">

## Add modifier value to max durability

Add a helper function `_getItemMaxDurability`. If the modifier of an item is `Durability ↑/↑↑`, the modifier value is added.