### PR TITLE
TOTK: improve fusion durability handling

### DIFF
--- a/zelda-totk/locale/zelda-totk.locale.es.js
+++ b/zelda-totk/locale/zelda-totk.locale.es.js
@@ -160,6 +160,8 @@ Locale.add('es', {
 'Modifier':'Modificador',
 'Modifier value':'Valor modificador',
 'Fusion':'Fusión',
+'Current Fuse Durability':'Actual durabilidad de fusión',
+'Max Fuse Durability':'Máxima durabilidad de fusión',
 'Dye color':'Color tinte',
 'Quantity':'Cantidad',
 'Heart quarters heal':'Cuartos de corazón curados',


### PR DESCRIPTION
Hi,

I noticed that this save editor does not restore durability properly for fused weapons. What it currently does is calculate the maximum durability of the weapon/shield given its modifiers, and if fused, then adds either 25 or the durability of the fused weapon/bow/shield. This second step is not correct, and this durability value gets overwritten by the maximum durability as soon as the weapon is equipped in-game. Also, if I want to set a weapon's durability to 1, such as to get a double damage *MsgNotFound* for example, this editor does not take into account the extra durability from fusion.

Using v1.1.0, I tried various combinations of fusing/unfusing objects/weapons/shields to other weapons/shields, and here is what I've learned:

## `extraDurability` and `recordExtraDurability`

- The extra durability from fuse is stored in the fields that are described in this code as `extraDurability` and `recordExtraDurability`. 
- `extraDurability` is always used up before `durability`. When fused objects are destroyed/unfused, the current `extraDurability` is set to 0, but the previous value remains in `recordExtraDurability`. If the save is edited to have a nonzero `extraDurability` value when unfused, this value doesn't get cleared until the weapon is fused again, so effectively the durability has increased.
-  `recordExtraDurability` and `extraDurability` have the same value while the weapon is fused. `recordExtraDurability` retains its value when unfused, and on the next fusion `extraDurability` is set to this value.
- `recordExtraDurability` for a new, unfused weapon is set to -1, and then becomes 25 (or whatever that max is for that weapon type) on the first fusion. Unfusing the weapon afterwords will leave this value as 25 (or the max). Weapons will have the sparkle effect when `durability` is max, and `recordExtraDurability` is either max or -1.
-  Shields do not seem to use either of these values, and `recordExtraDurability` always seems to be 0.
- This is involved in the Master Sword durability bug, as after the Master Sword recharges the `recordExtraDurability` field never gets reset to -1 when it should.

## `fuseDurability`
- When the fuse material is an object with durability like a weapon/shield/bow or Zonai device, the durability gets written to a field of the base fuse object that this code refers to as `fuseDurability`.
- This, along with the material type, seems to be the only data that is stored, so if the fuse material was a weapon/shield, then its modifiers and `recordExtraDurability` are lost.
- If the fuse material is a weapon, unfusing it in Tarrey Town will set its `recordExtraDurability` to -1. The base object's `recordExtraDurability` remains the same.
  - This means you can actually replenish weapon durability without an octorok, although not very practical. If a weapon is used with a fuse up to 25 times, unfused and fused to a weapon/shield, then broken apart, it will have all of its extra durability back.

## Changes

With the above in mind, I updated this code to edit `extraDurability` and `recordExtraDurability` for weapons, as well as set max durability for fused weapons/shields according to the checks the game seems to make. I obtained the extra max life values used here from [Echo's data sheet](https://docs.google.com/spreadsheets/d/18pNtDx3z-8CwGJRmlW574xbQ6VphQOkvpZhClpOEVDA/edit#gid=1957840503), with the ones without values set to 25. For restoring durability, I also restore `fuseDurability` if the fusion is a weapon/bow/shield. I did a bit of testing with various materials to find some also had nonzero `fuseDurability`, but since there are so many I didn't bother with finding all of the max values or making this field editable.

Además, hace muchos años desde yo tomé español en escuela, entonces mi traducción no es la mejor.

Fixes #385 