### PR TITLE
[TOTK] Fix exp calc incorrect skill points ceiling

### DIFF
--- a/zelda-totk/zelda-totk.exp-calculator.js
+++ b/zelda-totk/zelda-totk.exp-calculator.js
@@ -79,7 +79,7 @@ const ExperienceCalculator={
 
 			var PointSum = DefeatPoints + DefeatedNoDamagePoints + HeadshotPoints + GuardJustPoints + JustAvoidPoints;
 
-			totalExperience += Math.min(2*MaxNum*Points, PointSum);
+			totalExperience += Math.min(2*DefeatPoints, PointSum);
 		}
 		return totalExperience;
 	},


### PR DESCRIPTION
Realized that the calculation is only accurate if you have maxed out your defeat count and should now properly check the skill points ceiling based on your current defeat count.