### PR TITLE
TOTK: Add savegame slot picker

### DIFF
--- a/savegame-editor.js
+++ b/savegame-editor.js
@@ -24,6 +24,18 @@ MarcFile.prototype.writeU16String=function(pos,maxLength,str){
 	for(;i<maxLength;i++)
 		this.writeU16(pos+i*2,0)
 }
+MarcFile.newFromPromise=async function(file){
+	var ret = await new Promise((resolve, reject) => {
+		try {
+			var marcFile = new MarcFile(file, function() {
+				resolve(marcFile);
+			});
+		} catch (err) {
+			reject(err);
+		}
+	});
+	return ret;
+}
 
 
 
@@ -305,13 +317,13 @@ window.addEventListener('load', function(){
 	}
 
 
-	MarcDragAndDrop.add('dragzone', function(droppedFiles){
+	MarcDragAndDrop.add('dragzone', async function(droppedFiles){
 		if(droppedFiles.length == 1 || typeof SavegameEditor.showSavegameIndex === 'undefined') {
 			// Load savegame from file
 			tempFile=new MarcFile(droppedFiles[0], _tempFileLoadFunction);
 		} else {
 			// Some games have a complex structure of multiple savegames, so we provide a custom picker+overview
-			SavegameEditor.showSavegameIndex(droppedFiles);
+			await SavegameEditor.showSavegameIndex(droppedFiles);
 		}
 	});
 

--- a/zelda-totk/index.html
+++ b/zelda-totk/index.html
@@ -959,6 +959,9 @@
 </div>
 
 <div id="dialog-caption" class="dialog text-center"></div>
+<div id="dialog-savegameindex" class="dialog text-center">
+	<h3 data-translate="Select save slot to edit">Select save slot to edit</h3><div id="container-savegameslots"></div>
+</div>
 
 
 <div id="toasts-container"></div>

--- a/zelda-totk/locale/zelda-totk.locale.es.js
+++ b/zelda-totk/locale/zelda-totk.locale.es.js
@@ -13,6 +13,9 @@ Locale.add('es', {
 'Import':'Importar',
 'Duplicate':'Duplicar',
 'Delete':'Borrar',
+'Open':'Abrir',
+'Select save slot to edit': 'Selecciona guardar ranura para editar',
+'Autosave':'Guardado automático',
 
 
 /* navbar */

--- a/zelda-totk/zelda-totk.css
+++ b/zelda-totk/zelda-totk.css
@@ -41,6 +41,17 @@ body{
 }
 
 
+/* pick savegame slot screen */
+#container-savegameslots .row-item{
+	background-color: rgba(0,0,0,0.2);
+	padding:0;
+	margin:16px 0;
+	align-items:normal;
+	min-height:144px; /* caption 256x144 */
+	max-height:144px;
+}
+
+
 
 
 

--- a/zelda-totk/zelda-totk.js
+++ b/zelda-totk/zelda-totk.js
@@ -1065,6 +1065,10 @@ SavegameEditor={
 		return false
 	},
 
+	showSavegameIndex:function(droppedFiles) {
+		// TODO show slot picker with caption.sav metadata
+		console.log(droppedFiles);
+	},
 
 	preload:function(){
 		/* implement String.slug for item searching purposes */

--- a/zelda-totk/zelda-totk.js
+++ b/zelda-totk/zelda-totk.js
@@ -1018,30 +1018,49 @@ SavegameEditor={
 		MarcTooltips.add('#container-'+catId+' input',{position:'left',align:'center'});
 	},
 
+	captionReadBoolByHash:function(marcFile, targetHash) {
+		for(var i=0x000028; i<0x000001c0; i+=8){
+			var hash=marcFile.readU32(i);
+			if(hash===targetHash){
+				return marcFile.readBytes(i+4, 1)[0] == 1;
+			}
+		}
+		return false;
+	},
+
+	captionReadU32ByHash:function(marcFile, targetHash) {
+		for(var i=0x000028; i<0x000001c0; i+=8){
+			var hash=marcFile.readU32(i);
+			if(hash===targetHash){
+				return marcFile.readU32(i+4);
+			}
+		}
+	},
+
+	makeImgFromCaption:function(marcFile){
+		var jpgOffset = this.captionReadU32ByHash(marcFile, 0x63696a32);
+		var jpgSize=marcFile.readU32(jpgOffset);
+
+		var arrayBuffer=marcFile._u8array.buffer.slice(jpgOffset+4, jpgOffset+4+jpgSize);
+		var blob=new Blob([arrayBuffer], {type:'image/jpeg'});
+		var imageUrl=(window.URL || window.webkitURL).createObjectURL(blob);
+		var img=new Image();
+		img.src=imageUrl;
+		return img;
+	},
+
 	/* check if savegame is valid */
 	checkValidSavegame:function(){
 		tempFile.littleEndian=true;
 		//if(tempFile.fileName==='caption.sav'){
 		if(/caption/.test(tempFile.fileName)){
-			for(var i=0x000028; i<0x000001c0; i+=8){
-				var hash=tempFile.readU32(i);
-				if(hash===0x63696a32){ //found JPG hash
-					var jpgOffset=tempFile.readU32(i+4);
-					var jpgSize=tempFile.readU32(jpgOffset);
-
-					var arrayBuffer=tempFile._u8array.buffer.slice(jpgOffset+4, jpgOffset+4+jpgSize);
-					var blob=new Blob([arrayBuffer], {type:'image/jpeg'});
-					var imageUrl=(window.URL || window.webkitURL).createObjectURL(blob);
-					var img=new Image();
-					img.src=imageUrl;
-					document.getElementById('dialog-caption').innerHTML='';
-					document.getElementById('dialog-caption').appendChild(img);
-					window.setTimeout(function(){
-						MarcDialogs.open('caption')
-					}, 100);
-
-					break;
-				}
+			var img = this.makeImgFromCaption(tempFile);
+			if(img){
+				document.getElementById('dialog-caption').innerHTML='';
+				document.getElementById('dialog-caption').appendChild(img);
+				window.setTimeout(function(){
+					MarcDialogs.open('caption')
+				}, 100);
 			}
 		}else if(tempFile.readU32(0)===0x01020304 && tempFile.fileSize>=2307552 && tempFile.fileSize<4194304){
 			Variable.findHashTableEnd();
@@ -1065,9 +1084,92 @@ SavegameEditor={
 		return false
 	},
 
-	showSavegameIndex:function(droppedFiles) {
-		// TODO show slot picker with caption.sav metadata
-		console.log(droppedFiles);
+	showSavegameIndex:async function(droppedFiles) {
+		// Parse savegames into their respective slots
+		var slotCaptionDate = [];
+		var slotCaptionImg = [];
+		var slotCaptionIsAutosave = [];
+		var slotProgressMarcFile = [];
+		for(var i=0; i<droppedFiles.length; i++) {
+			var file = droppedFiles[i];
+			var filePath = file.webkitRelativePath || ''; // non standard but supported everywhere
+			var slotMatch = filePath.match(/slot_0([012345])/);
+			if(!slotMatch || slotMatch.length != 2) {
+				continue;
+			}
+			var slot_i = parseInt(slotMatch[1]);
+
+			if(file.name == "caption.sav") {
+				var marcFile = await MarcFile.newFromPromise(file);
+				marcFile.littleEndian = true; // this gets hardcoded in checkValidSavegame too
+
+				var year = this.captionReadU32ByHash(marcFile, 0x9811A3F7);
+				var minute = this.captionReadU32ByHash(marcFile, 0x27853BF7);
+				var hour = this.captionReadU32ByHash(marcFile, 0x23F3D75E);
+				var month = this.captionReadU32ByHash(marcFile, 0xDFD840D3);
+				var day = this.captionReadU32ByHash(marcFile, 0xBD46F485);
+				var slotDate = new Date(year, month-1, day, hour, minute);
+				slotCaptionDate[slot_i] = slotDate;
+
+				var isAutosave = this.captionReadBoolByHash(marcFile, 0x25F03CAA);
+				slotCaptionIsAutosave[slot_i] = isAutosave;
+				//console.log(slot_i, slotDate, isAutosave);
+
+				var img = this.makeImgFromCaption(marcFile);
+				slotCaptionImg[slot_i] = img;
+			} else if(file.name == "progress.sav") {
+				var marcFile = await MarcFile.newFromPromise(file);
+				marcFile.littleEndian = true; // this gets hardcoded in checkValidSavegame too
+				slotProgressMarcFile[slot_i] = marcFile;
+			}
+		}
+		// Sort slot indexes by date descending, ranking hardsaves higher on tie
+		var sortedSlots = slotCaptionDate.map((x,i) => [x,i]).sort((a,b) => {
+			var cmp = b[0]-a[0];
+			if (cmp) { return cmp; }
+			return slotCaptionIsAutosave[a[1]]-slotCaptionIsAutosave[b[1]];
+		}).map(pair => pair[1]);
+
+		// Show slot picker with caption.sav metadata
+		$('#container-savegameslots').html('');
+		for(let i=0; i<6; i++) {
+			let slot_i = sortedSlots[i];
+			var img = slotCaptionImg[slot_i];
+			var progressMarcFile = slotProgressMarcFile[slot_i];
+
+			var row = $('<div></div>').addClass('row row-item');
+			var columnLeft = $('<div></div>').addClass('row-item-left');
+			var columnRight = $('<div></div>').addClass('row-item-right');
+			row.append(columnLeft, columnRight);
+
+			if(img){
+				columnLeft.append(img);
+				var button = $('<button></button>').addClass('btn').text(_('Open') + ' slot_0' + slot_i).on('click', (evt)=>{
+					MarcDialogs.close();
+					tempFile = slotProgressMarcFile[slot_i];
+					_tempFileLoadFunction();
+				});
+
+				var slotDate = new Intl.DateTimeFormat(undefined, {
+					dateStyle: 'short',
+					timeStyle: 'short',
+				}).format(slotCaptionDate[slot_i]);
+				slotDate = $("<div></div>").text(slotDate);
+
+				columnRight.append(slotDate, button);
+
+				if(slotCaptionIsAutosave[slot_i]) {
+					var autosaveTag = $("<div></div>").text(_("Autosave"));
+					columnRight.append(autosaveTag);
+				}
+			}
+
+			$('#container-savegameslots').append(row);
+		}
+
+		window.setTimeout(function(){
+			MarcDialogs.open('savegameindex')
+		}, 100);
 	},
 
 	preload:function(){

--- a/zelda-totk/zelda-totk.js
+++ b/zelda-totk/zelda-totk.js
@@ -1,5 +1,5 @@
 /*
-	The legend of Zelda: Tears of the Kingdom savegame editor (last update 2024-01-02)
+	The legend of Zelda: Tears of the Kingdom savegame editor (last update 2024-02-11)
 
 	by Marc Robledo 2023-2024
 */


### PR DESCRIPTION
This is an alternate way to launch the TOTK editor:
- Everything is the same when a single file is provided
- Slot picker dialog is shown when the whole save folder is dropped in
- User must still pick the destination file when saving as usual, this is only an open helper

![totk_example](https://github.com/marcrobledo/savegame-editors/assets/137466401/e86ea403-0d76-48f3-8187-99d394a28e44)
