### PR TITLE
Add Weather / TimeDayLookWorld

### DIFF
--- a/zelda-totk/zelda-totk.hashes.csv
+++ b/zelda-totk/zelda-totk.hashes.csv
@@ -29418,7 +29418,7 @@ e16bb54b;IntArray;WeaponStand.EquipInfo.Content.Effect.Value
 8ed131e0;IntArray;WeaponStand.EquipInfo.Content.ExtraLife
 6b4f749f;IntArray;WeaponStand.EquipInfo.Content.Life
 54824e22;IntArray;WeaponStand.EquipInfo.Content.RecordExtraLife
-0744746a;IntArray;Unknown
+0744746a;IntArray;World_WeatherForecast
 5cd322a7;String32;TempName.Mane
 a0e854ea;String64;LastWildHorse.ActorName
 558901d7;String64;NpcGardenInfo.GrowActorName
@@ -30983,7 +30983,7 @@ f78a5054;UInt;RandomPlacedItemCreateActor_SouthernVillageGamblerShopTBox.Elapsed
 07a98af6;UInt;RandomPlacedItemCreateActor_SouthernVillageGamblerShopTBox.OpenElapsedTime
 2029d3d8;UInt;Unknown
 b8ef33e4;UInt;Unknown
-3f8d9d86;UInt;Unknown
+3f8d9d86;UInt;TimeDayLookWorld
 5ce8221a;UInt64;LastWildHorse.UidHash
 1aeff61b;UInt64;World_BloodyMoonTimer
 ef10b80f;UInt64;World_CurrentDateTime


### PR DESCRIPTION
#### Add `TimeDayLookWorld` (Total Minutes playing)
   This tracks along with `World_CurrentDays` `World_CurrentHour`, and `World_CurrentMinute`
   It is close to `0xe573f564` Playtime (in seconds) but different by -100 to 400 seconds.
   The value does not wrap on the Blood Moon

####  Add `World_WeatherForecast`

I don't know how you would like to handle the weathers (or if you do at all). I am hopefully giving you enough information below.  If any of this is unclear, please let me know.
 
Weather Data:
   `IntArray[936 = mClimates * mDays * mTimes]`
   or
    `IntArray[mClimates][mDays][mTimes]`
 assuming incremental `mTimes` are in neighbors in memory

`IntArray[#]` holds an index from `WeatherTypes` identifying the weather.

   where 
```javascript 
WeatherTypes = [
  'BlueSky', 'Cloudy', 'Rain',
  'HeavyRain', 'Snow', 'HeavySnow',
  'ThunderStorm', 'ThunderRain',  'BlueSkyRain',
  'CaveRain',  'SuperHeavySnow',
]
// WeatherType Invalid = -1 

mClimates.length = 52
mDays = [0, 1, 2] // Length 3
mTimes = [ // Length 6
  t_12AM4AM,  t_4AM8AM,  t_8AM12PM,  t_12PM4PM,  t_4PM,8PM,  t_8PM12AM
]

mClimates = [
   "HyrulePlainClimate", "NorthHyrulePlainClimate", "HebraFrostClimate",
   "TabantaAridClimate", "FrostClimate", "GerudoDesertClimate", 
   "GerudoPlateauClimate", "EldinClimateLv0", "TamourPlainClimate", 
   "ZoraTemperateClimate", "HateruPlainClimate", "FiloneSubtropicalClimate", 
   "SouthHateruHumidTempClimate", "EldinClimateLv1", "EldinClimateLv2", 
   "DarkWoodsClimate", "LostWoodClimate", "GerudoFrostClimate", 
   "KorogForest", "GerudoDesertClimateLv2", "ZonaiSkyClimate", 
   "DefaultUndergroundClimate", "HebraSkyClimate", "GerudoDesertClimate_Abnormal", 
   "Rito_Abnormal", "EldinUnderGroundClimateLv0", "EldinUnderGroundClimateLv1", 
   "EldinUnderGroundClimateLv2", "FrostSkyClimate", "GerudoFrostSkyClimate", 
   "GerudoDesertClimate_AbnormalSmall", "GerudoCanyon", "GerudoCanyon_BufferZone", 
   "BeginningPlateauFrostClimate", "LostWoodClimate_Abnormal", "ZoraTemperateClimate_Abnormal", 
   "KorogForest_Abnormal", "GerudoUndergroundClimateLv1", "HebraUndergroundClimate", 
   "HebraSkyCumulonimbus", "RyutojimaSkyClimate", "RyutojimaSkyClimate_Abnormal", 
   "Ichikara_Climate", "DarkDragonSkyClimate", "HebraSkyCumulonimbus_Inner",
   "GerudoSkyClimate", "TabantaAridClimate_Rain", "ZoraSkyClimate_Abnormal", 
   "BeginningSkyClimate", "BeginningSkyClimate_Demo", "GanondorfUndergroundClimate", 
   "KorogForestSkyClimate"
]

```
Each of the `mClimates` identifies (one to many) the climate of map regions (see Field Map Areas for all of the layers)
