### PR TITLE
Add Travel Medallion Support

### DIFF
--- a/zelda-totk/zelda-totk.class.item.js
+++ b/zelda-totk/zelda-totk.class.item.js
@@ -810,6 +810,8 @@ Item.AVAILABILITY={
 		'Energy_Material_01', //Crystallized Charge
 		'MinusRupee_00', //Poe
 		'Obj_StableHostlePointCard', //Pony Points Card
+		'Obj_WarpDLC', //Travel Medallion'
+		'Obj_WarpDLC_Prototype', //Travel Medallion (prototype)
 
 		'Obj_DefeatHonor_00', //Stone Talus Monster Medal
 		'Obj_DefeatHonor_01', //Hinox Monster Medal


### PR DESCRIPTION
Based on a quick check, it seems like there's currently no support for adding the Travel Medallion to your inventory, nor the prototype for it.

I've now added those to the items list, and it seems like they can now be modded in.