### PR TITLE
[totk] CSS tweak for overflow in slot dialog

### DIFF
--- a/zelda-totk/zelda-totk.css
+++ b/zelda-totk/zelda-totk.css
@@ -42,6 +42,10 @@ body{
 
 
 /* pick savegame slot screen */
+#container-savegameslots{
+	max-height: 90vh;
+	overflow: scroll;
+}
 #container-savegameslots .row-item{
 	background-color: rgba(0,0,0,0.2);
 	padding:0;


### PR DESCRIPTION
allows the save slot picker dialog contents to scroll when it's getting too tall -- relevant for zooming or short displays 

before -- cannot view bottom slots at 720p
![image](https://github.com/user-attachments/assets/0364589a-a002-4e1d-a668-dd9443e7c158)

after -- we can scroll the dialog contents to access them
![image](https://github.com/user-attachments/assets/17bd6821-9092-409b-afea-24c13e3f75da)
